### PR TITLE
Ensure referenced records are deleted before company record

### DIFF
--- a/Data/CompanyDatabase.cs
+++ b/Data/CompanyDatabase.cs
@@ -128,7 +128,8 @@ namespace ErpCli.Data
             using (SqlCommand command = connection.CreateCommand())
             {
                 command.Transaction = transaction;
-                command.CommandText = @"DELETE FROM Companies WHERE Id = @id";
+                command.CommandText = @"DELETE FROM Persons WHERE CompanyId = @id;
+                                        DELETE FROM Companies WHERE Id = @id";
                 command.Parameters.AddWithValue("@id", id);
                 if (command.ExecuteNonQuery() == 0)
                 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data integrity for company deletion. The system now properly removes all associated personnel records when deleting a company, ensuring no orphaned data remains and maintaining referential consistency across the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->